### PR TITLE
Fix for multi-catch requiring API level 19

### DIFF
--- a/ex/HobbitContentProvider/AndroidManifest.xml
+++ b/ex/HobbitContentProvider/AndroidManifest.xml
@@ -4,7 +4,7 @@
       android:versionCode="1"
       android:versionName="1.0">
   <uses-sdk
-     android:minSdkVersion="18"
+     android:minSdkVersion="19"
      android:targetSdkVersion="22" />
 
   <application


### PR DESCRIPTION
Basically I was getting the warning (Android studio) "multi-catch with these reflection exceptions require API level 19.." etc. The reason was that the target minimum SDK was set to 18. This simply changes it to 19. Dont really think this is an issue.
