### PR TITLE
Added code in MainActivity.java and ContactOps.java to handle impleme…

### DIFF
--- a/ex/ContactsContentProvider/src/vandy/mooc/activities/ContactsActivity.java
+++ b/ex/ContactsContentProvider/src/vandy/mooc/activities/ContactsActivity.java
@@ -95,14 +95,14 @@ public class ContactsActivity
         switch (item.getItemId()) {
         case R.id.simpleImpl:
             getOps().setContactsOpsImplType
-                (ContactsOps.ContactsOpsImplType.SIMPLE);
+                    (ContactsOps.ContactsOpsImplType.SIMPLE);
             Utils.showToast(this,
                             "ContactsOpsImplSimple selected");
             break;
 
         case R.id.asyncImpl:
             getOps().setContactsOpsImplType
-                (ContactsOps.ContactsOpsImplType.ASYNC); 
+                (ContactsOps.ContactsOpsImplType.ASYNC);
             Utils.showToast(this,
                             "ContactsOpsImplAsync selected");
             break;
@@ -114,6 +114,18 @@ public class ContactsActivity
                             "ContactsOpsImplLoaderManager selected");
             break;
         }
+
+        // The calls to setContactsOpsImplType above will both set
+        // the new implementation type as well as construct a new
+        // instance of that implementation. This requires initializing
+        // the implementation weak reference to the this Activity,
+        // which can be accomplished by generating a fake configuration
+        // change event. Also, since the ContactOps implementation was
+        // just constructed and is not being restored, we need to pass
+        // in true for the "firstTimeIn" in parameter.
+        //
+        getOps().onConfiguration(this, true);
+
         return true;
     }
 

--- a/ex/ContactsContentProvider/src/vandy/mooc/operations/ContactsOps.java
+++ b/ex/ContactsContentProvider/src/vandy/mooc/operations/ContactsOps.java
@@ -38,8 +38,7 @@ public class ContactsOps implements ConfigurableOps {
      * Stores the type of the ContactsOpsImpl (i.e., SIMPLE, ASYNC, or
      * LOADER_MANAGER).
      */
-    private ContactsOpsImplType mImplType =
-        ContactsOpsImplType.SIMPLE;
+    private ContactsOpsImplType mImplType = null;
 
     /**
      * The root of the Implementor hierarchy.
@@ -51,18 +50,7 @@ public class ContactsOps implements ConfigurableOps {
      * class to work properly.
      */
     public ContactsOps() {
-        // Select the appropriate type of ContactsOpsImpl.
-        switch(mImplType) {
-        case SIMPLE:
-            mImpl = new ContactsOpsImplSimple();
-            break;
-        case ASYNC:
-            mImpl = new ContactsOpsImplAsync();
-            break;
-        case LOADER_MANAGER:
-            mImpl = new ContactsOpsImplLoaderManager();
-            break;
-        }
+        setContactsOpsImplType(ContactsOpsImplType.SIMPLE);
     }
 
     /**
@@ -114,6 +102,20 @@ public class ContactsOps implements ConfigurableOps {
      * LOADER_MANAGER).
      */
     public void setContactsOpsImplType(ContactsOpsImplType implType) {
-        mImplType = implType;
+        // Set and construct the appropriate type of ContactsOpsImpl.
+        if (implType != mImplType) {
+            mImplType = implType;
+            switch(mImplType) {
+                case SIMPLE:
+                    mImpl = new ContactsOpsImplSimple();
+                    break;
+                case ASYNC:
+                    mImpl = new ContactsOpsImplAsync();
+                    break;
+                case LOADER_MANAGER:
+                    mImpl = new ContactsOpsImplLoaderManager();
+                    break;
+            }
+        }
     }
 }


### PR DESCRIPTION
Changed ContanctsActivity.java and ContactOps.java to support dynamically changing implementation. The previous version did not support this functionality because only the ContactOps type was changed, but no new implementation instances were generated to support the type change. To make things simple and straightforward, I handled the setting of weak references for each new instance by simply calling getOps.onConfiguration() from main activity.
