### PR TITLE
Trim EditText input.

### DIFF
--- a/assignments/assignment1/src/vandy/mooc/activities/AcronymActivity.java
+++ b/assignments/assignment1/src/vandy/mooc/activities/AcronymActivity.java
@@ -77,7 +77,7 @@ public class AcronymActivity extends GenericActivity<AcronymOps> {
         // consistent with what we get back from the Acronym web
         // service.
         final String acronym =
-            mEditText.getText().toString().toUpperCase(Locale.ENGLISH);
+            mEditText.getText().toString().trim().toUpperCase(Locale.ENGLISH);
 
         if (acronym.isEmpty())
             Utils.showToast(this,


### PR DESCRIPTION
Summary:
If the user mistypes a linefeed or a whitespaces by the end of the text input,
no acronym is found. Thus these extra characteres should be removed.
