### PR TITLE
Updating spring-data-dynamodb version

### DIFF
--- a/examples/11-VideoServiceWithDynamoDB/build.gradle
+++ b/examples/11-VideoServiceWithDynamoDB/build.gradle
@@ -47,13 +47,13 @@ dependencies {
     compile("org.springframework.boot:spring-boot-starter-aop")
     compile("org.springframework.boot:spring-boot-starter-test")
     compile("org.springframework.data:spring-data-rest-webmvc:2.1.0.RELEASE")
-   
-    compile("org.socialsignin:spring-data-dynamodb:1.0.1-SNAPSHOT")
-    
+
+    compile("org.socialsignin:spring-data-dynamodb:1.0.4-SNAPSHOT")
+
     compile("com.google.guava:guava:17.0")
     compile("com.squareup.retrofit:retrofit:1.6.0")
     compile("commons-io:commons-io:2.4")
-    
+
     testCompile("junit:junit")
 }
 

--- a/examples/11b-VideoServiceWithDynamoDBBeanstalk/build.gradle
+++ b/examples/11b-VideoServiceWithDynamoDBBeanstalk/build.gradle
@@ -36,7 +36,7 @@ repositories {
 
 dependencies {
 
-    compile("org.springframework.boot:spring-boot-starter-web") 
+    compile("org.springframework.boot:spring-boot-starter-web")
     providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")
 
     compile("org.springframework.data:spring-data-commons:1.8.0.RELEASE")
@@ -45,13 +45,13 @@ dependencies {
     compile("org.springframework.boot:spring-boot-starter-aop")
     compile("org.springframework.boot:spring-boot-starter-test")
     compile("org.springframework.data:spring-data-rest-webmvc:2.1.0.RELEASE")
-   
-    compile("org.socialsignin:spring-data-dynamodb:1.0.1-SNAPSHOT")
-    
+
+    compile("org.socialsignin:spring-data-dynamodb:1.0.4-SNAPSHOT")
+
     compile("com.google.guava:guava:17.0")
     compile("com.squareup.retrofit:retrofit:1.6.0")
     compile("commons-io:commons-io:2.4")
-    
+
     testCompile("junit:junit")
 }
 


### PR DESCRIPTION
Previous versions of the spring-data-dynamodb had internal dependency conflicts which caused the example project to throw a runtime exception.  The newest snapshot version of the spring-data-dynamodb project fixes that.
